### PR TITLE
Add Postgres and Redis support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11 as builder
 
-ENV APP_VERSION 1.1.0
+ENV APP_VERSION 2.0.0
 
 RUN mkdir -p /usr/src/app
 

--- a/client_test.go
+++ b/client_test.go
@@ -24,7 +24,6 @@ var statsdTests = []struct {
 			&prefix,
 			map[string]logValue{
 				"at":      {"info", ""},
-				"path":    {"/foo", ""},
 				"connect": {"1", "ms"},
 				"service": {"37", "ms"},
 				"status":  {"401", ""},
@@ -42,71 +41,7 @@ var statsdTests = []struct {
 	{
 		cnt: 1,
 		m: logMetrics{
-			metricsTag,
-			&app,
-			&tags,
-			&prefix,
-			map[string]logValue{
-				"metric#load_avg_2m": {"0.01", ""},
-			},
-			events,
-		},
-		Expected: []string{
-			"prefix.app.metric.load.avg.2m:0.010000|g|#tag1,tag2",
-		},
-	},
-	{
-		cnt: 1,
-		m: logMetrics{
-			metricsTag,
-			&app,
-			&tags,
-			&prefix,
-			map[string]logValue{
-				"sample#load_avg_1m": {"0.01", ""},
-			},
-			events,
-		},
-		Expected: []string{
-			"prefix.app.metric.load.avg.1m:0.010000|g|#tag1,tag2",
-		},
-	},
-	{
-		cnt: 1,
-		m: logMetrics{
-			metricsTag,
-			&app,
-			&tags,
-			&prefix,
-			map[string]logValue{
-				"count#clicks": {"1", ""},
-			},
-			events,
-		},
-		Expected: []string{
-			"prefix.app.metric.clicks:1|c|#tag1,tag2",
-		},
-	},
-	{
-		cnt: 1,
-		m: logMetrics{
-			metricsTag,
-			&app,
-			&tags,
-			&prefix,
-			map[string]logValue{
-				"measure#temperature": {"1.3", ""},
-			},
-			events,
-		},
-		Expected: []string{
-			"prefix.app.metric.temperature:1.300000|h|#tag1,tag2",
-		},
-	},
-	{
-		cnt: 1,
-		m: logMetrics{
-			sampleMsg,
+			dynoSampleMsg,
 			&app,
 			&tags,
 			&prefix,
@@ -117,7 +52,7 @@ var statsdTests = []struct {
 			events,
 		},
 		Expected: []string{
-			"prefix.heroku.dyno.load.avg.1m:0.010000|g|#source:web1,tag1,tag2",
+			"prefix.heroku.dyno.load_avg_1m:0.010000|g|#source:web1,tag1,tag2",
 		},
 	},
 	{

--- a/logproc_test.go
+++ b/logproc_test.go
@@ -9,11 +9,14 @@ import (
 
 func TestLogProc(t *testing.T) {
 
-	lines := strings.Split(`255 <158>1 2015-04-02T11:52:34.520012+00:00 host heroku router - at=info method=POST path="/users" host=myapp.com request_id=c1806361-2081-42e7-a8aa-92b6808eac8e fwd="24.76.242.18" dyno=web.1 connect=1ms service=37ms status=201 bytes=828
-229 <45>1 2015-04-02T11:48:16.839257+00:00 host heroku web.1 - source=web.1 dyno=heroku.35930502.b9de5fce-44b7-4287-99a7-504519070cba sample#load_avg_1m=0.01 sample#load_avg_5m=0.02 sample#load_avg_15m=0.03
-222 <134>1 2017-05-13T15:35:33.787162+00:00 host app api - Scaled to mailer@3:Performance-L web@5:Standard-2X by user someuser@gmail.com
-222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - this_is="broken
-222 <134>1 2015-04-07T16:01:43.517062+00:00 host app api - Release v138 created by user foo@bar`, "\n")
+	lines := strings.Split(
+		`255 <158>1 2015-04-02T11:52:34.520012+00:00 host heroku router - at=info method=POST path="/users" host=myapp.com request_id=c1806361-2081-42e7-a8aa-92b6808eac8e fwd="24.76.242.18" dyno=web.1 connect=1ms service=37ms status=201 bytes=828
+		229 <45>1 2015-04-02T11:48:16.839257+00:00 host heroku web.1 - source=web.1 dyno=heroku.35930502.b9de5fce-44b7-4287-99a7-504519070cba sample#load_avg_1m=0.01 sample#load_avg_5m=0.02 sample#load_avg_15m=0.03
+		542 <134>1 2015-04-02T11:47:55+00:00 host app heroku-postgres - source=HEROKU_POSTGRESQL_TEAL addon=foo sample#current_transaction=6709 sample#db_size=18032824bytes sample#tables=16 sample#active-connections=4 sample#waiting-connections=0 sample#index-cache-hit-rate=0.99971 sample#table-cache-hit-rate=0.99892 sample#load-avg-1m=0.315 sample#load-avg-5m=0.22 sample#load-avg-15m=0.225 sample#read-iops=25.996 sample#write-iops=1.629 sample#memory-total=15666128kB sample#memory-free=233092kB sample#memory-cached=14836812kB sample#memory-postgres=170376kB
+		542 <134>1 2015-04-02T11:47:55+00:00 host app heroku-redis - source=REDIS addon=foo sample#active-connections=73 sample#load-avg-1m=0 sample#load-avg-5m=0 sample#load-avg-15m=0 sample#read-iops=0 sample#write-iops=0 sample#memory-total=15664328kB sample#memory-free=14828336kB sample#memory-cached=237920kB sample#memory-redis=176289040bytes sample#hit-rate=0.85243 sample#evicted-keys=0
+		222 <134>1 2017-05-13T15:35:33.787162+00:00 host app api - Scaled to mailer@3:Performance-L web@5:Standard-2X by user someuser@gmail.com
+		222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - this_is="broken
+		222 <134>1 2015-04-07T16:01:43.517062+00:00 host app api - Release v138 created by user foo@bar`, "\n")
 
 	app := "test"
 	tags := []string{"tag1", "tag2"}
@@ -37,8 +40,18 @@ func TestLogProc(t *testing.T) {
 	}
 
 	res = <-s.out
-	if res.typ != sampleMsg {
-		t.Error("result must be SAMPLE")
+	if res.typ != dynoSampleMsg {
+		t.Error("result must be DYNO SAMPLE")
+	}
+
+	res = <-s.out
+	if res.typ != pgSampleMsg {
+		t.Error("result must be POSTGRES SAMPLE")
+	}
+
+	res = <-s.out
+	if res.typ != redisSampleMsg {
+		t.Error("result must be REDIS SAMPLE")
 	}
 
 	res = <-s.out

--- a/server_test.go
+++ b/server_test.go
@@ -22,16 +22,33 @@ var fullTests = []struct {
 		cnt: 3,
 		Req: `255 <158>1 2015-04-02T11:52:34.520012+00:00 host heroku router - at=info method=POST path="/users" host=myapp.com request_id=c1806361-2081-42e7-a8aa-92b6808eac8e fwd="24.76.242.18" dyno=web.1 connect=1ms service=37ms status=201 bytes=828`,
 		Expected: []string{
-			"heroku.router.response.bytes:828.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,path:/users,status:201,statusFamily:2xx",
-			"heroku.router.request.connect:1.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,path:/users,status:201,statusFamily:2xx",
-			"heroku.router.request.service:37.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,path:/users,status:201,statusFamily:2xx",
+			"heroku.router.response.bytes:828.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,status:201,statusFamily:2xx",
+			"heroku.router.request.connect:1.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,status:201,statusFamily:2xx",
+			"heroku.router.request.service:37.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,status:201,statusFamily:2xx",
 		},
 	},
 	{
-		cnt: 1,
-		Req: `229 <45>1 2015-04-02T11:48:16.839257+00:00 host heroku web.1 - source=web.1 dyno=heroku.35930502.b9de5fce-44b7-4287-99a7-504519070cba sample#load_avg_1m=0.01`,
+		cnt: 2,
+		Req: `229 <45>1 2015-04-02T11:48:16.839257+00:00 host heroku web.1 - source=web.1 dyno=heroku.35930502.b9de5fce-44b7-4287-99a7-504519070cba sample#load_avg_1m=0.01 sample#load-avg-5m=0`,
 		Expected: []string{
-			"heroku.dyno.load.avg.1m:0.010000|g|#source:web.1,type:web",
+			"heroku.dyno.load_avg_1m:0.010000|g|#dyno:web.1,dynotype:web",
+			"heroku.dyno.load_avg_5m:0.000000|g|#dyno:web.1,dynotype:web",
+		},
+	},
+	{
+		cnt: 2,
+		Req: `542 <134>1 2015-04-02T11:47:55+00:00 host app heroku-postgres - source=HEROKU_POSTGRESQL_TEAL sample#memory-free=233092kB sample#load-avg-5m=0`,
+		Expected: []string{
+			"heroku.postgres.memory_free:233092.000000|g|#source:HEROKU_POSTGRESQL_TEAL",
+			"heroku.postgres.load_avg_5m:0.000000|g|#source:HEROKU_POSTGRESQL_TEAL",
+		},
+	},
+	{
+		cnt: 2,
+		Req: `542 <134>1 2015-04-02T11:47:55+00:00 host app heroku-redis - source=REDIS sample#memory-redis=176289040bytes sample#load-avg-5m=0`,
+		Expected: []string{
+			"heroku.redis.memory_redis:176289040.000000|g|#source:REDIS",
+			"heroku.redis.load_avg_5m:0.000000|g|#source:REDIS",
 		},
 	},
 	{
@@ -48,21 +65,6 @@ var fullTests = []struct {
 		Req: `222 <134>1 2015-04-07T16:01:43.517062+00:00 host app api - Release v1 created by foo@bar`,
 		Expected: []string{
 			"_e{13,29}:app/api: test|Release v1 created by foo@bar",
-		},
-	},
-	{
-		cnt: 9,
-		Req: `452 <134>1 2015-04-07T16:01:43.517062+00:00 host app web.1 - info: responseLogger: metric#tag#route=/parser metric#request_id=11747467-f4ce-4b06-8c99-92be968a02e3 metric#request_length=541 metric#response_length=5163 metric#parser_time=5ms metric#eventLoop.count=606 metric#eventLoop.avg_ms=515.503300330033 metric#eventLoop.p50_ms=0.8805309734513275 metric#eventLoop.p95_ms=3457.206896551724 metric#eventLoop.p99_ms=3457.206896551724 metric#eventLoop.max_ms=5008`,
-		Expected: []string{
-			"app.metric.request.length:541.000000|g|#source:web.1,type:web,route:/parser",
-			"app.metric.response.length:5163.000000|g|#source:web.1,type:web,route:/parser",
-			"app.metric.parser.time:5.000000|g|#source:web.1,type:web,route:/parser",
-			"app.metric.eventLoop.count:606.000000|g|#source:web.1,type:web,route:/parser",
-			"app.metric.eventLoop.avg.ms:515.503300|g|#source:web.1,type:web,route:/parser",
-			"app.metric.eventLoop.p50.ms:0.880531|g|#source:web.1,type:web,route:/parser",
-			"app.metric.eventLoop.p95.ms:3457.206897|g|#source:web.1,type:web,route:/parser",
-			"app.metric.eventLoop.p99.ms:3457.206897|g|#source:web.1,type:web,route:/parser",
-			"app.metric.eventLoop.max.ms:5008.000000|g|#source:web.1,type:web,route:/parser",
 		},
 	},
 }


### PR DESCRIPTION
Updates the drain to support metrics for Postgres and Redis. Removes support for custom metrics since we don't need it.

Metrics will come to Datadog as:
* Dyno: `heroku.dyno.load_avg_1m`
* Redis: `heroku.redis.load_avg_1m`
* Postgres: `heroku.postgres.load_avg_1m`